### PR TITLE
Fixed DllImports

### DIFF
--- a/src/Current/HidLibrary/NativeMethods.cs
+++ b/src/Current/HidLibrary/NativeMethods.cs
@@ -43,25 +43,19 @@ namespace HidLibrary
 	    static internal extern bool CloseHandle(IntPtr hObject);
 
 	    [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-	    static internal extern int CreateEvent(ref SECURITY_ATTRIBUTES securityAttributes, int bManualReset, int bInitialState, string lpName);
+	    static internal extern IntPtr CreateEvent(ref SECURITY_ATTRIBUTES securityAttributes, int bManualReset, int bInitialState, string lpName);
 
 	    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
 	    static internal extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess, int dwShareMode, ref SECURITY_ATTRIBUTES lpSecurityAttributes, int dwCreationDisposition, int dwFlagsAndAttributes, int hTemplateFile);
 
-	    [DllImport("kernel32.dll", SetLastError = true)]
-	    static internal extern bool ReadFile(IntPtr hFile, ref byte lpBuffer, int nNumberOfBytesToRead, ref int lpNumberOfBytesRead, IntPtr lpOverlapped);
-
-	    [DllImport("kernel32.dll", SetLastError = true, EntryPoint = "ReadFile")]
-	    static internal extern bool ReadFileOverlapped(IntPtr hFile, ref byte lpBuffer, int nNumberOfBytesToRead, ref int lpNumberOfBytesRead, ref OVERLAPPED lpOverlapped);
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static internal extern bool ReadFile(IntPtr hFile, [Out] byte[] lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, [In] ref System.Threading.NativeOverlapped lpOverlapped);
 
 	    [DllImport("kernel32.dll")]
-	    static internal extern uint WaitForSingleObject(int hHandle, int dwMilliseconds);
+	    static internal extern uint WaitForSingleObject(IntPtr hHandle, int dwMilliseconds);
 
-	    [DllImport("kernel32.dll", SetLastError = true)]
-	    static internal extern bool WriteFileOverlapped(IntPtr hFile, ref byte lpBuffer, int nNumberOfBytesToWrite, ref int lpNumberOfBytesWritten, ref OVERLAPPED lpOverlapped);
-
-	    [DllImport("kernel32.dll", SetLastError = true)]
-	    static internal extern bool WriteFile(IntPtr hFile, ref byte lpBuffer, int nNumberOfBytesToWrite, ref int lpNumberOfBytesWritten, int lpOverlapped);
+        [DllImport("kernel32.dll")]
+        static internal extern bool WriteFile(IntPtr hFile, byte[] lpBuffer, uint nNumberOfBytesToWrite, out uint lpNumberOfBytesWritten, [In] ref System.Threading.NativeOverlapped lpOverlapped);
 
 	    internal const int DBT_DEVICEARRIVAL = 0x8000;
 	    internal const int DBT_DEVICEREMOVECOMPLETE = 0x8004;

--- a/src/Current/TestHarness/Main.cs
+++ b/src/Current/TestHarness/Main.cs
@@ -121,7 +121,9 @@ namespace TestHarness
         private void ReadHandler(HidReport report)
         {
             Output.Clear();
-            Output.AppendText(System.Text.Encoding.ASCII.GetString(report.Data));
+            Output.AppendText(String.Join(" ", report.Data.Select(d => d.ToString("X2"))));
+
+            _deviceList[Devices.SelectedIndex].ReadReport(ReadProcess);
         }
 
         private static void WriteResult(bool success)
@@ -131,7 +133,7 @@ namespace TestHarness
 
         private void RefreshDevices()
         {
-            _deviceList = HidDevices.Enumerate(0x0801, 0x0002).ToArray();
+            _deviceList = HidDevices.Enumerate().ToArray();
             //_deviceList = HidDevices.Enumerate(0x536, 0x207, 0x1c7).ToArray();
             Devices.DisplayMember = "Description";
             Devices.DataSource = _deviceList;


### PR DESCRIPTION
I was trying out your library but wasn't getting any sensible data on either ReadData or ReadReport. Quick inspection learned that your DllImports for ReadFile and WriteFile were incorrect. I have attached a commit which includes the correct definitions and also updates the rest of the source code to match the changes.

I only tested on Win7 x64 but the changes should also work on x86.

Regards,
Benjamin
