### PR TITLE
Fix for handle leak in HidDevice.ReadData()

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -439,6 +439,7 @@ namespace HidLibrary
                         }
                     }
                     catch { status = HidDeviceData.ReadStatus.ReadError; }
+                    finally { CloseDeviceIO(overlapped.EventHandle); }
                 }
                 else
                 {


### PR DESCRIPTION
Hi there,
thanks for the great library, saved me so much headache on a small private project!

The ReadData function in class HidDevice was leaking handles.
This patch should stop this and the resulting leak of private bytes.

Thanks again,
best regards,
Julian Siebert
