### PR TITLE
Cleaned up my changes

### DIFF
--- a/src/HidLibrary/HidDeviceAttributes.cs
+++ b/src/HidLibrary/HidDeviceAttributes.cs
@@ -17,5 +17,6 @@
         public int Version { get; private set; }
         public string VendorHexId { get; set; }
         public string ProductHexId { get; set; }
+        public string BusReportedDescription { get; set; }
     }
 }

--- a/src/HidLibrary/HidDevices.cs
+++ b/src/HidLibrary/HidDevices.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace HidLibrary
 {
@@ -77,6 +78,42 @@ namespace HidLibrary
             }
         }
 
+        private static IEnumerable<HidDevice> EnumerateHidDeviceInstances()
+        {
+            var hidClass = HidClassGuid;
+            var deviceInfoSet = NativeMethods.SetupDiGetClassDevs(ref hidClass, null, 0, NativeMethods.DIGCF_PRESENT | NativeMethods.DIGCF_DEVICEINTERFACE);
+
+            if (deviceInfoSet.ToInt32() != NativeMethods.INVALID_HANDLE_VALUE)
+            {
+                var devices = new List<HidDevice>();
+                var deviceInfoData = CreateDeviceInfoData();
+                var deviceIndex = 0;
+
+                while (NativeMethods.SetupDiEnumDeviceInfo(deviceInfoSet, deviceIndex, ref deviceInfoData))
+                {
+                    deviceIndex += 1;
+
+                    var deviceInterfaceData = new NativeMethods.SP_DEVICE_INTERFACE_DATA();
+                    deviceInterfaceData.cbSize = Marshal.SizeOf(deviceInterfaceData);
+                    var deviceInterfaceIndex = 0;
+
+                    while (NativeMethods.SetupDiEnumDeviceInterfaces(deviceInfoSet, 0, ref hidClass, deviceInterfaceIndex, ref deviceInterfaceData))
+                    {
+                        deviceInterfaceIndex++;
+                        var devicePath = GetDevicePath(deviceInfoSet, deviceInterfaceData);
+
+                        var tempDevice = new HidDevice(devicePath);
+                        tempDevice.Attributes.BusReportedDescription = GetDeviceBusReportedDescription(deviceInfoSet, ref deviceInfoData);
+                        if (devices.Any(x => x.DevicePath == devicePath))
+                            continue;
+
+                        yield return tempDevice;
+                    }
+                }
+                NativeMethods.SetupDiDestroyDeviceInfoList(deviceInfoSet);
+            }
+        }
+
         private static NativeMethods.SP_DEVINFO_DATA CreateDeviceInfoData()
         {
             var deviceInfoData = new NativeMethods.SP_DEVINFO_DATA();
@@ -98,6 +135,77 @@ namespace HidLibrary
 
             return NativeMethods.SetupDiGetDeviceInterfaceDetail(deviceInfoSet, ref deviceInterfaceData, ref interfaceDetail, bufferSize, ref bufferSize, IntPtr.Zero) ? 
                 interfaceDetail.DevicePath : null;
+        }
+
+        private static string GetAsUTF8String(byte[] buffer)
+        {
+            var tempString = Encoding.UTF8.GetString(buffer);
+            return tempString.Remove(tempString.IndexOf((char)0));
+        }
+
+        private static string GetAsUTF16String(byte[] buffer)
+        {
+            var tempString = Encoding.Unicode.GetString(buffer);
+            return tempString.Remove(tempString.IndexOf((char)0));
+        }
+
+        private static string GetDeviceBusReportedDescription(IntPtr deviceInfoSet, ref NativeMethods.SP_DEVINFO_DATA devinfoData)
+        {
+            byte[] descriptionBuffer = new byte[1024];
+
+            int requiredSize = 0;
+            int type = 0;
+
+            // This function is available everywhere
+            NativeMethods.SetupDiGetDeviceRegistryProperty(deviceInfoSet,
+                                                            ref devinfoData,
+                                                            NativeMethods.SPDRP_DEVICEDESC,
+                                                            ref type,
+                                                            descriptionBuffer,
+                                                            descriptionBuffer.Length,
+                                                            ref requiredSize);
+
+            string deviceDescription = GetAsUTF8String(descriptionBuffer);
+
+            string reportedDeviceDescription = string.Empty;
+
+            // TODO: Check windows version
+            try
+            {
+                descriptionBuffer = new byte[1024];
+                ulong propertyType = 0;
+                requiredSize = 0;
+
+                // This function is only available from Vista onwards
+                bool _continue = NativeMethods.SetupDiGetDeviceProperty(deviceInfoSet,
+                                                                        ref devinfoData,
+                                                                        NativeMethods.DEVPKEY_Device_BusReportedDeviceDesc,
+                                                                        ref propertyType,
+                                                                        descriptionBuffer,
+                                                                        descriptionBuffer.Length,
+                                                                        ref requiredSize,
+                                                                        0);
+
+                if (_continue)
+                {
+                    reportedDeviceDescription = GetAsUTF16String(descriptionBuffer);
+                }
+                else
+                {
+                    int error = Marshal.GetLastWin32Error();
+
+                    //Log("Error, GetLastError={0}", error);
+                }
+            }
+            catch (MissingMethodException e)
+            {
+                //Log("Likely we're running on XP", e);
+            }
+
+            if (reportedDeviceDescription != string.Empty)
+                return reportedDeviceDescription;
+
+            return deviceDescription;
         }
 
         private static Guid HidClassGuid

--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -36,6 +36,8 @@ namespace HidLibrary
 		    public bool bInheritHandle;
 	    }
 
+        
+
 	    [DllImport("kernel32.dll")]
 	    static internal extern int CancelIo(int hFile);
 
@@ -103,6 +105,12 @@ namespace HidLibrary
 
         internal const int SPDRP_UPPERFILTERS = 0x11;
 
+        internal static DEVPROPKEY DEVPKEY_Device_BusReportedDeviceDesc = new DEVPROPKEY
+            {
+                fmtid = new Guid(0x540b947e, 0x8b40, 0x45bc, 0xa8, 0xa2, 0x6a, 0x0b, 0x89, 0x4c, 0xbd, 0xa2),
+                pid = 4,
+            };
+
 	    [StructLayout(LayoutKind.Sequential)]
 	    internal class DEV_BROADCAST_DEVICEINTERFACE
 	    {
@@ -169,8 +177,19 @@ namespace HidLibrary
             internal string DevicePath;
         }
 
+        // Device Property
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct DEVPROPKEY
+        {
+            public Guid fmtid;
+            public ulong pid;
+        }
+
 	    [DllImport("setupapi.dll", EntryPoint = "SetupDiGetDeviceRegistryProperty")]
-	    public static extern bool SetupDiGetDeviceRegistryProperty(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA deviceInfoData, int propertyVal, int propertyRegDataType, byte[] propertyBuffer, int propertyBufferSize, IntPtr requiredSize);
+	    public static extern bool SetupDiGetDeviceRegistryProperty(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA deviceInfoData, int propertyVal, ref int propertyRegDataType, byte[] propertyBuffer, int propertyBufferSize, ref int requiredSize);
+
+        [DllImport("setupapi.dll", EntryPoint = "SetupDiGetDevicePropertyW", SetLastError = true)]
+        public static extern bool SetupDiGetDeviceProperty(IntPtr deviceInfo, ref SP_DEVINFO_DATA deviceInfoData, DEVPROPKEY propkey, ref ulong propertyDataType, byte[] propertyBuffer, int propertyBufferSize, ref int requiredSize, int zerothis);
 
 	    [DllImport("setupapi.dll")]
 	    static internal extern bool SetupDiEnumDeviceInfo(IntPtr deviceInfoSet, int memberIndex, ref SP_DEVINFO_DATA deviceInfoData);

--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -204,7 +204,7 @@ namespace HidLibrary
 	    static internal extern int SetupDiDestroyDeviceInfoList(IntPtr deviceInfoSet);
 
 	    [DllImport("setupapi.dll")]
-	    static internal extern bool SetupDiEnumDeviceInterfaces(IntPtr deviceInfoSet, int deviceInfoData, ref System.Guid interfaceClassGuid, int memberIndex, ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData);
+	    static internal extern bool SetupDiEnumDeviceInterfaces(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA deviceInfoData, ref System.Guid interfaceClassGuid, int memberIndex, ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData);
 
 	    [DllImport("setupapi.dll", CharSet = CharSet.Auto)]
         static internal extern IntPtr SetupDiGetClassDevs(ref System.Guid classGuid, string enumerator, int hwndParent, int flags);


### PR DESCRIPTION
Functionality is the same; there is still some code duplication, but the commit is clean otherwise.

----

Added BusReportedDescription property to HidDeviceAttributes
Filled above property with information from SetupDiGetDeviceProperty (available on Vista and onwards)
Added native reference to SetupDiGetDeviceProperty
Added native DEVPROPKEY struct and defined the BusReportedDescription key
**Changed last field of SetupDiGetDeviceRegistryProperty from IntPtr to ref int.**

modified:   src/HidLibrary/HidDeviceAttributes.cs
modified:   src/HidLibrary/HidDevices.cs
modified:   src/HidLibrary/NativeMethods.cs
