### PR TITLE
Added HidFastReadDevice class

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -20,8 +20,8 @@ namespace HidLibrary
         private readonly HidDeviceEventMonitor _deviceEventMonitor;
         
         private bool _monitorDeviceEvents;
-        private delegate HidDeviceData ReadDelegate();
-        private delegate HidReport ReadReportDelegate();
+        protected delegate HidDeviceData ReadDelegate();
+        protected delegate HidReport ReadReportDelegate();
         private delegate bool WriteDelegate(byte[] data);
         private delegate bool WriteReportDelegate(HidReport report);
 
@@ -351,7 +351,7 @@ namespace HidLibrary
             return success;
         }
 
-        private static void EndRead(IAsyncResult ar)
+        protected static void EndRead(IAsyncResult ar)
         {
             var hidAsyncState = (HidAsyncState)ar.AsyncState;
             var callerDelegate = (ReadDelegate)hidAsyncState.CallerDelegate;
@@ -361,7 +361,7 @@ namespace HidLibrary
             if ((callbackDelegate != null)) callbackDelegate.Invoke(data);
         }
 
-        private static void EndReadReport(IAsyncResult ar)
+        protected static void EndReadReport(IAsyncResult ar)
         {
             var hidAsyncState = (HidAsyncState)ar.AsyncState;
             var callerDelegate = (ReadReportDelegate)hidAsyncState.CallerDelegate;
@@ -489,7 +489,7 @@ namespace HidLibrary
             }
         }
 
-        private HidDeviceData ReadData(int timeout)
+        protected HidDeviceData ReadData(int timeout)
         {
             var buffer = new byte[] { };
             var status = HidDeviceData.ReadStatus.NoDataRead;

--- a/src/HidLibrary/HidFastReadDevice.cs
+++ b/src/HidLibrary/HidFastReadDevice.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace HidLibrary
+{
+    public class HidFastReadDevice : HidDevice
+    {
+        // FastRead assumes that the device is connected,
+        // which could cause stability issues if hardware is
+        // disconnected during a read
+        public HidDeviceData FastRead()
+        {
+            return FastRead(0);
+        }
+
+        public HidDeviceData FastRead(int timeout)
+        {
+            try
+            {
+                return ReadData(timeout);
+            }
+            catch
+            {
+                return new HidDeviceData(HidDeviceData.ReadStatus.ReadError);
+            }
+        }
+
+        public void FastRead(ReadCallback callback)
+        {
+            var readDelegate = new ReadDelegate(FastRead);
+            var asyncState = new HidAsyncState(readDelegate, callback);
+            readDelegate.BeginInvoke(EndRead, asyncState);
+        }
+
+        public void FastReadReport(ReadReportCallback callback)
+        {
+            var readReportDelegate = new ReadReportDelegate(FastReadReport);
+            var asyncState = new HidAsyncState(readReportDelegate, callback);
+            readReportDelegate.BeginInvoke(EndReadReport, asyncState);
+        }
+
+        public HidReport FastReadReport(int timeout)
+        {
+            return new HidReport(Capabilities.InputReportByteLength, FastRead(timeout));
+        }
+
+        public HidReport FastReadReport()
+        {
+            return FastReadReport(0);
+        }
+    }
+}

--- a/src/HidLibrary/HidLibrary.csproj
+++ b/src/HidLibrary/HidLibrary.csproj
@@ -48,6 +48,7 @@
     <Compile Include="HidDeviceCapabilities.cs" />
     <Compile Include="HidDeviceData.cs" />
     <Compile Include="HidDeviceEventMonitor.cs" />
+    <Compile Include="HidFastReadDevice.cs" />
     <Compile Include="IHidEnumerator.cs" />
     <Compile Include="HidDevices.cs" />
     <Compile Include="HidReport.cs" />

--- a/src/HidLibrary/Properties/AssemblyInfo.cs
+++ b/src/HidLibrary/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.1.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]


### PR DESCRIPTION
Implements FastRead and FastReadReport methods without checking connection status first. The user would need to check connection status periodically. This addresses issue #42.
