### PR TITLE
Add Async methods to IHidDevice interface

### DIFF
--- a/src/HidLibrary/IHidDevice.cs
+++ b/src/HidLibrary/IHidDevice.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace HidLibrary


### PR DESCRIPTION
Recently added async methods were not present on the interface.
