### PR TITLE
add method ChangeClassGuid(Guid g)

### DIFF
--- a/src/HidLibrary/HidDevices.cs
+++ b/src/HidLibrary/HidDevices.cs
@@ -107,6 +107,11 @@ namespace HidLibrary
                 return _hidClassGuid;
             }
         }
+        
+        public static void ChangeClassGuid(Guid g)
+        {
+            _hidClassGuid = g;
+        }
 
         private static string GetDeviceDescription(IntPtr deviceInfoSet, ref NativeMethods.SP_DEVINFO_DATA devinfoData)
         {


### PR DESCRIPTION
_hidClassGuid should have a public setter because I need to enumerate more device types but not only the HID GUID returned by HidD_GetHidGuid  ( e.g. GUID_DEVINTERFACE_USBPRINT (0x28d78fad, 0x5a12, 0x11d1, 0xae, 0x5b, 0x00, 0x00, 0xf8, 0x03, 0xa8, 0xc2)