### PR TITLE
Fix #62: Increase buffer size for device string read operations.

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -225,7 +225,7 @@ namespace HidLibrary
 
         public bool ReadProduct(out byte[] data)
         {
-            data = new byte[64];
+            data = new byte[254];
             IntPtr hidHandle = IntPtr.Zero;
             bool success = false;
             try
@@ -252,7 +252,7 @@ namespace HidLibrary
 
         public bool ReadManufacturer(out byte[] data)
         {
-            data = new byte[64];
+            data = new byte[254];
             IntPtr hidHandle = IntPtr.Zero;
             bool success = false;
             try
@@ -279,7 +279,7 @@ namespace HidLibrary
 
         public bool ReadSerialNumber(out byte[] data)
         {
-            data = new byte[64];
+            data = new byte[254];
             IntPtr hidHandle = IntPtr.Zero;
             bool success = false;
             try


### PR DESCRIPTION
MSDN says that devices are allowed to return 126 wide characters (plus a terminating null) for each of the underlying HID calls made in `ReadProduct`, `ReadManufacturer`, and `ReadSerialNumber`.

[Documentation for HidD_GetProductString, for example.](https://msdn.microsoft.com/en-us/library/ff539681.aspx)

This means 254 bytes should be allocated before each of these calls, not the 64 bytes I allowed. This was a silly mistake related to the device I was using when I wrote these methods.

Lesson learned: always read the docs before calling system functions.