### PR TITLE
Add HidFastReadEnumerator

### DIFF
--- a/src/HidLibrary/HidDevices.cs
+++ b/src/HidLibrary/HidDevices.cs
@@ -41,9 +41,9 @@ namespace HidLibrary
             return EnumerateDevices().Select(x => new HidDevice(x.Path, x.Description)).Where(x => x.Attributes.VendorId == vendorId);
         }
 
-        private class DeviceInfo { public string Path { get; set; } public string Description { get; set; } }
+        internal class DeviceInfo { public string Path { get; set; } public string Description { get; set; } }
 
-        private static IEnumerable<DeviceInfo> EnumerateDevices()
+        internal static IEnumerable<DeviceInfo> EnumerateDevices()
         {
             var devices = new List<DeviceInfo>();
             var hidClass = HidClassGuid;

--- a/src/HidLibrary/HidFastReadEnumerator.cs
+++ b/src/HidLibrary/HidFastReadEnumerator.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace HidLibrary
+{
+    public class HidFastReadEnumerator : IHidEnumerator
+    {
+        public bool IsConnected(string devicePath)
+        {
+            return HidDevices.IsConnected(devicePath);
+        }
+
+        public IHidDevice GetDevice(string devicePath)
+        {
+            return Enumerate(devicePath).FirstOrDefault() as IHidDevice;
+        }
+
+        public IEnumerable<IHidDevice> Enumerate()
+        {
+            return HidDevices.EnumerateDevices().
+                Select(d => new HidFastReadDevice(d.Path, d.Description) as IHidDevice);
+        }
+
+        public IEnumerable<IHidDevice> Enumerate(string devicePath)
+        {
+            return HidDevices.EnumerateDevices().Where(x => x.Path == devicePath).
+                Select(d => new HidFastReadDevice(d.Path, d.Description) as IHidDevice);
+        }
+
+        public IEnumerable<IHidDevice> Enumerate(int vendorId, params int[] productIds)
+        {
+            return HidDevices.EnumerateDevices().Select(d => new HidFastReadDevice(d.Path, d.Description)).
+                Where(f => f.Attributes.VendorId == vendorId && productIds.Contains(f.Attributes.ProductId)).
+                Select(d => d as IHidDevice);
+        }
+
+        public IEnumerable<IHidDevice> Enumerate(int vendorId)
+        {
+            return HidDevices.EnumerateDevices().Select(d => new HidFastReadDevice(d.Path, d.Description)).
+                Where(f => f.Attributes.VendorId == vendorId).
+                Select(d => d as IHidDevice);
+        }
+    }
+}

--- a/src/HidLibrary/HidLibrary.csproj
+++ b/src/HidLibrary/HidLibrary.csproj
@@ -52,6 +52,7 @@
     <Compile Include="HidDeviceData.cs" />
     <Compile Include="HidDeviceEventMonitor.cs" />
     <Compile Include="HidFastReadDevice.cs" />
+    <Compile Include="HidFastReadEnumerator.cs" />
     <Compile Include="IHidEnumerator.cs" />
     <Compile Include="HidDevices.cs" />
     <Compile Include="HidReport.cs" />

--- a/src/Tests/Hid.cs
+++ b/src/Tests/Hid.cs
@@ -1,12 +1,11 @@
-﻿using NUnit.Framework;
+﻿using Xunit;
 using Should;
 
-namespace Tests
+namespace HidLibrary.Tests
 {
-    [TestFixture]
     public class Hid
     {
-        [Test]
+        [Fact]
         public void Get_Some_Tests_In_Here()
         {
             true.ShouldBeTrue();

--- a/src/Tests/HidEnumerator.cs
+++ b/src/Tests/HidEnumerator.cs
@@ -1,20 +1,17 @@
-﻿using NUnit.Framework;
-using HidLibrary;
+﻿using Xunit;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Should;
 
-namespace Tests
+namespace HidLibrary.Tests
 {
-    [TestFixture]
     public class HidEnumeratorTests
     {
         private HidEnumerator enumerator;
         private string devicePath;
 
-        [SetUp]
-        public void beforeEach()
+        public void BeforeEach()
         {
             enumerator = new HidEnumerator();
             var firstDevice = enumerator.Enumerate().FirstOrDefault();
@@ -29,42 +26,47 @@ namespace Tests
             }
         }
 
-        [Test]
+        [Fact]
         public void CanConstruct()
         {
+            BeforeEach();
             enumerator.ShouldBeType(typeof(HidEnumerator));
         }
 
-        [Test]
+        [Fact]
         public void WrapsIsConnected()
         {
+            BeforeEach();
             bool enumIsConnected = enumerator.IsConnected(devicePath);
             bool hidIsConnected = HidDevices.IsConnected(devicePath);
             enumIsConnected.ShouldEqual(hidIsConnected);
         }
 
-        [Test]
+        [Fact]
         public void WrapsGetDevice()
         {
+            BeforeEach();
             IHidDevice enumDevice = enumerator.GetDevice(devicePath);
             IHidDevice hidDevice = HidDevices.GetDevice(devicePath);
             enumDevice.DevicePath.ShouldEqual(hidDevice.DevicePath);
         }
 
-        [Test]
+        [Fact]
         public void WrapsEnumerateDefault()
         {
+            BeforeEach();
             IEnumerable<IHidDevice> enumDevices = enumerator.Enumerate();
             IEnumerable<IHidDevice> hidDevices = HidDevices.Enumerate().
                 Select(d => d as IHidDevice);
 
             
-            allDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
         }
 
-        [Test]
+        [Fact]
         public void WrapsEnumerateDevicePath()
         {
+            BeforeEach();
             IEnumerable<IHidDevice> enumDevices =
                 enumerator.Enumerate(devicePath);
             IEnumerable<IHidDevice> hidDevices =
@@ -72,13 +74,14 @@ namespace Tests
                     Select(d => d as IHidDevice);
 
 
-            allDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
         }
 
-        [Test]
+        [Fact]
         public void WrapsEnumerateVendorId()
         {
-            int vid = getVid();
+            BeforeEach();
+            int vid = GetVid();
 
             IEnumerable<IHidDevice> enumDevices =
                 enumerator.Enumerate(vid);
@@ -87,14 +90,15 @@ namespace Tests
                     Select(d => d as IHidDevice);
 
 
-            allDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
         }
 
-        [Test]
+        [Fact]
         public void WrapsEnumerateVendorIdProductId()
         {
-            int vid = getVid();
-            int pid = getPid();
+            BeforeEach();
+            int vid = GetVid();
+            int pid = GetPid();
 
             IEnumerable<IHidDevice> enumDevices =
                 enumerator.Enumerate(vid, pid);
@@ -103,11 +107,10 @@ namespace Tests
                     Select(d => d as IHidDevice);
 
 
-            allDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
         }
 
-
-        private bool allDevicesTheSame(IEnumerable<IHidDevice> a,
+        private bool AllDevicesTheSame(IEnumerable<IHidDevice> a,
             IEnumerable<IHidDevice> b)
         {
             if(a.Count() != b.Count())
@@ -133,17 +136,17 @@ namespace Tests
             return allSame;
         }
 
-        private int getVid()
+        private int GetVid()
         {
-            return getNumberFromRegex("vid_([0-9a-f]{4})");
+            return GetNumberFromRegex("vid_([0-9a-f]{4})");
         }
 
-        private int getPid()
+        private int GetPid()
         {
-            return getNumberFromRegex("pid_([0-9a-f]{3,4})");
+            return GetNumberFromRegex("pid_([0-9a-f]{3,4})");
         }
 
-        private int getNumberFromRegex(string pattern)
+        private int GetNumberFromRegex(string pattern)
         {
             var match = Regex.Match(devicePath, pattern,
                 RegexOptions.IgnoreCase);

--- a/src/Tests/HidFastReadEnumerator.cs
+++ b/src/Tests/HidFastReadEnumerator.cs
@@ -1,0 +1,176 @@
+﻿namespace HidLibrary.Tests
+{
+    using Xunit;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Should;
+
+    namespace Tests
+    {
+        public class HidFastReadEnumeratorTests
+        {
+            private HidFastReadEnumerator enumerator;
+            private string devicePath;
+            
+            public void BeforeEach()
+            {
+                enumerator = new HidFastReadEnumerator();
+                var firstDevice = enumerator.Enumerate().FirstOrDefault();
+
+                if (firstDevice != null)
+                {
+                    devicePath = firstDevice.DevicePath;
+                }
+                else
+                {
+                    devicePath = "";
+                }
+            }
+
+            [Fact]
+            public void CanConstruct()
+            {
+                BeforeEach();
+                enumerator.ShouldBeType(typeof(HidFastReadEnumerator));
+            }
+
+            [Fact]
+            public void WrapsIsConnected()
+            {
+                BeforeEach();
+                bool enumIsConnected = enumerator.IsConnected(devicePath);
+                bool hidIsConnected = HidDevices.IsConnected(devicePath);
+                enumIsConnected.ShouldEqual(hidIsConnected);
+            }
+
+            [Fact]
+            public void WrapsGetDevice()
+            {
+                BeforeEach();
+                IHidDevice enumDevice = enumerator.GetDevice(devicePath);
+                IHidDevice hidDevice = HidDevices.GetDevice(devicePath);
+                enumDevice.DevicePath.ShouldEqual(hidDevice.DevicePath);
+            }
+
+            [Fact]
+            public void WrapsEnumerateDefault()
+            {
+                BeforeEach();
+                IEnumerable<IHidDevice> enumDevices = enumerator.Enumerate();
+                IEnumerable<IHidDevice> hidDevices = HidDevices.Enumerate().
+                    Select(d => d as IHidDevice);
+
+
+                AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void WrapsEnumerateDevicePath()
+            {
+                BeforeEach();
+                IEnumerable<IHidDevice> enumDevices =
+                    enumerator.Enumerate(devicePath);
+                IEnumerable<IHidDevice> hidDevices =
+                    HidDevices.Enumerate(devicePath).
+                        Select(d => d as IHidDevice);
+
+
+                AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void WrapsEnumerateVendorId()
+            {
+                BeforeEach();
+                int vid = GetVid();
+
+                IEnumerable<IHidDevice> enumDevices =
+                    enumerator.Enumerate(vid);
+                IEnumerable<IHidDevice> hidDevices =
+                    HidDevices.Enumerate(vid).
+                        Select(d => d as IHidDevice);
+
+
+                AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void WrapsEnumerateVendorIdProductId()
+            {
+                BeforeEach();
+                int vid = GetVid();
+                int pid = GetPid();
+
+                IEnumerable<IHidDevice> enumDevices =
+                    enumerator.Enumerate(vid, pid);
+                IEnumerable<IHidDevice> hidDevices =
+                    HidDevices.Enumerate(vid, pid).
+                        Select(d => d as IHidDevice);
+
+
+                AllDevicesTheSame(enumDevices, hidDevices).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void DevicesAreFastRead()
+            {
+                BeforeEach();
+                HidFastReadDevice device = enumerator.GetDevice(devicePath) as HidFastReadDevice;
+                device.ShouldNotBeNull();
+            }
+
+            private bool AllDevicesTheSame(IEnumerable<IHidDevice> a,
+                IEnumerable<IHidDevice> b)
+            {
+                if (a.Count() != b.Count())
+                    return false;
+
+                bool allSame = true;
+
+                var aList = a.ToList();
+                var bList = b.ToList();
+
+                int numDevices = aList.Count;
+
+                for (int i = 0; i < numDevices; i++)
+                {
+                    if (aList[i].DevicePath !=
+                        bList[i].DevicePath)
+                    {
+                        allSame = false;
+                        break;
+                    }
+                }
+
+                return allSame;
+            }
+
+            private int GetVid()
+            {
+                return GetNumberFromRegex("vid_([0-9a-f]{4})");
+            }
+
+            private int GetPid()
+            {
+                return GetNumberFromRegex("pid_([0-9a-f]{3,4})");
+            }
+
+            private int GetNumberFromRegex(string pattern)
+            {
+                var match = Regex.Match(devicePath, pattern,
+                    RegexOptions.IgnoreCase);
+
+                int num = 0;
+
+                if (match.Success)
+                {
+                    num = int.Parse(match.Groups[1].Value,
+                        System.Globalization.NumberStyles.HexNumber);
+                }
+
+                return num;
+            }
+        }
+    }
+}

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -13,6 +14,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,15 +41,6 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NSubstitute.1.7.2.0\lib\NET45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="nunit.mocks">
-      <HintPath>..\packages\NUnit.2.5.10.11092\lib\nunit.mocks.dll</HintPath>
-    </Reference>
-    <Reference Include="pnunit.framework">
-      <HintPath>..\packages\NUnit.2.5.10.11092\lib\pnunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="Should">
       <HintPath>..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>
     </Reference>
@@ -57,10 +51,23 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HidEnumerator.cs" />
     <Compile Include="Hid.cs" />
+    <Compile Include="HidFastReadEnumerator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -76,6 +83,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
-  <package id="NUnit" version="2.5.10.11092" />
   <package id="Should" version="1.1.12.0" />
+  <package id="xunit" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I got an email with a request for an enumerator implementation for my `HidFastReadDevice`. This has been unit-tested but not verified with any actual hardware.

In the process of implementing this, I decided to make `HidDevices.EnumerateDevices` internal rather than private. That method contains the system calls necessary to perform a proper enumeration, and it made sense to me not to repeat that code elsewhere.

I also replaced my NUnit tests with XUnit, since the NUnit tests weren't discoverable in the latest Visual Studio versions without installing a separate program. I doubt anyone was running my unit tests before, so hopefully that won't break anyone else's work.