### PR TITLE
Expose GetInputReport and SetOutputReport through native interface

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -112,6 +112,22 @@ namespace HidLibrary
             IsOpen = false;
         }
 
+        public byte[] GetInputReport(byte reportId, int bufferSize)
+        {
+            byte[] cmdBuffer = new byte[bufferSize];
+            cmdBuffer[0] = reportId;
+            NativeMethods.HidD_GetInputReport(Handle, cmdBuffer, cmdBuffer.Length);
+            return cmdBuffer;
+        }
+
+        public bool SetOutputReport(byte[] buffer)
+        {
+            if (null != buffer)
+                return (NativeMethods.HidD_SetOutputReport(Handle, buffer, buffer.Length));
+            else
+                throw new ArgumentException("The output buffer is null, it must be allocated before you call this method", "buffer");
+        }
+
         public HidDeviceData Read()
         {
             return Read(0);

--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -112,22 +112,6 @@ namespace HidLibrary
             IsOpen = false;
         }
 
-        public byte[] GetInputReport(byte reportId, int bufferSize)
-        {
-            byte[] cmdBuffer = new byte[bufferSize];
-            cmdBuffer[0] = reportId;
-            NativeMethods.HidD_GetInputReport(Handle, cmdBuffer, cmdBuffer.Length);
-            return cmdBuffer;
-        }
-
-        public bool SetOutputReport(byte[] buffer)
-        {
-            if (null != buffer)
-                return (NativeMethods.HidD_SetOutputReport(Handle, buffer, buffer.Length));
-            else
-                throw new ArgumentException("The output buffer is null, it must be allocated before you call this method", "buffer");
-        }
-
         public HidDeviceData Read()
         {
             return Read(0);
@@ -195,6 +179,22 @@ namespace HidLibrary
         {
             var readReportDelegate = new ReadReportDelegate(ReadReport);
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);
+        }
+
+        /// <summary>
+        /// Reads an input report from the Control channel.  This method provides access to report data for devices that 
+        /// do not use the interrupt channel to communicate for specific usages.
+        /// </summary>
+        /// <param name="reportId">The report ID to read from the device</param>
+        /// <returns>The HID report that is read.  The report will contain the success status of the read request</returns>
+        /// 
+        public HidReport ReadReportSync(byte reportId)
+        {
+            byte[] cmdBuffer = new byte[Capabilities.InputReportByteLength];
+            cmdBuffer[0] = reportId;
+            bool bSuccess = NativeMethods.HidD_GetInputReport(Handle, cmdBuffer, cmdBuffer.Length);
+            HidDeviceData deviceData = new HidDeviceData(cmdBuffer, bSuccess ? HidDeviceData.ReadStatus.Success : HidDeviceData.ReadStatus.NoDataRead);
+            return new HidReport(Capabilities.InputReportByteLength, deviceData);
         }
 
         public bool ReadFeatureData(out byte[] data, byte reportId = 0)
@@ -380,6 +380,25 @@ namespace HidLibrary
             var writeReportDelegate = new WriteReportDelegate(WriteReport);
             var asyncState = new HidAsyncState(writeReportDelegate, callback);
             writeReportDelegate.BeginInvoke(report, timeout, EndWriteReport, asyncState);
+        }
+
+        /// <summary>
+        /// Handle data transfers on the control channel.  This method places data on the control channel for devices
+        /// that do not support the interupt transfers
+        /// </summary>
+        /// <param name="report">The outbound HID report</param>
+        /// <returns>The result of the tranfer request: true if successful otherwise false</returns>
+        /// 
+        public bool WriteReportSync(HidReport report)
+        {
+
+            if (null != report)
+            {
+                byte[] buffer = report.GetBytes();
+                return (NativeMethods.HidD_SetOutputReport(Handle, buffer, buffer.Length));
+            }
+            else
+                throw new ArgumentException("The output report is null, it must be allocated before you call this method", "report");
         }
 
         public async Task<bool> WriteReportAsync(HidReport report, int timeout = 0)

--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -300,7 +300,7 @@ namespace HidLibrary
 	    static internal extern bool HidD_GetFeature(IntPtr hidDeviceObject, byte[] lpReportBuffer, int reportBufferLength);
 
 	    [DllImport("hid.dll")]
-	    static internal extern bool HidD_GetInputReport(IntPtr hidDeviceObject, ref byte lpReportBuffer, int reportBufferLength);
+	    static internal extern bool HidD_GetInputReport(IntPtr hidDeviceObject, byte[] lpReportBuffer, int reportBufferLength);
 
 	    [DllImport("hid.dll")]
 	    static internal extern void HidD_GetHidGuid(ref Guid hidGuid);


### PR DESCRIPTION
I needed access to a couple of the native methods hidden in the NativeMethods private class so I exposed them in the HidDevice class