### PR TITLE
Fixes for ReadReport timeouts and lost reports after wait timeouts

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -615,28 +615,28 @@ namespace HidLibrary
                         var success = NativeMethods.ReadFile(Handle, nonManagedBuffer, (uint)buffer.Length, out bytesRead, ref overlapped);
 
                         if (!success) {
-                        var result = NativeMethods.WaitForSingleObject(overlapped.EventHandle, overlapTimeout);
+                            var result = NativeMethods.WaitForSingleObject(overlapped.EventHandle, overlapTimeout);
 
-                        switch (result) 
-						{
-                            case NativeMethods.WAIT_OBJECT_0:
+                            switch (result) 
+                            {
+                                case NativeMethods.WAIT_OBJECT_0:
                                     status = HidDeviceData.ReadStatus.Success;
-                                    var s = NativeMethods.GetOverlappedResult(Handle, ref overlapped, out bytesRead, false);
+                                    NativeMethods.GetOverlappedResult(Handle, ref overlapped, out bytesRead, false);
                                     break;
-                            case NativeMethods.WAIT_TIMEOUT:
-                                status = HidDeviceData.ReadStatus.WaitTimedOut;
-                                buffer = new byte[] { };
-                                break;
+                                case NativeMethods.WAIT_TIMEOUT:
+                                    status = HidDeviceData.ReadStatus.WaitTimedOut;
+                                    buffer = new byte[] { };
+                                    break;
                             case NativeMethods.WAIT_FAILED:
-                                status = HidDeviceData.ReadStatus.WaitFail;
-                                buffer = new byte[] { };
-                                break;
-                            default:
-                                status = HidDeviceData.ReadStatus.NoDataRead;
-                                buffer = new byte[] { };
-                                break;
+                                    status = HidDeviceData.ReadStatus.WaitFail;
+                                    buffer = new byte[] { };
+                                    break;
+                                default:
+                                    status = HidDeviceData.ReadStatus.NoDataRead;
+                                    buffer = new byte[] { };
+                                    break;
+                            }
                         }
-                    }
                         Marshal.Copy(nonManagedBuffer, buffer, 0, (int)bytesRead);
                     }
                     catch { status = HidDeviceData.ReadStatus.ReadError; }

--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -17,7 +17,7 @@ namespace HidLibrary
 	    internal const uint WAIT_OBJECT_0 = 0;
 	    internal const uint WAIT_FAILED = 0xffffffff;
 
-	    internal const int WAIT_INFINITE = 0xffff;
+        internal const int WAIT_INFINITE = -1;
 	    [StructLayout(LayoutKind.Sequential)]
 	    internal struct OVERLAPPED
 	    {
@@ -55,10 +55,13 @@ namespace HidLibrary
 	    static internal extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess, int dwShareMode, ref SECURITY_ATTRIBUTES lpSecurityAttributes, int dwCreationDisposition, int dwFlagsAndAttributes, int hTemplateFile);
 
         [DllImport("kernel32.dll", SetLastError = true)]
-        static internal extern bool ReadFile(IntPtr hFile, [Out] byte[] lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, [In] ref System.Threading.NativeOverlapped lpOverlapped);
+        static internal extern bool ReadFile(IntPtr hFile, IntPtr lpBuffer, uint nNumberOfBytesToRead, out uint lpNumberOfBytesRead, [In] ref System.Threading.NativeOverlapped lpOverlapped);
 
 	    [DllImport("kernel32.dll")]
 	    static internal extern uint WaitForSingleObject(IntPtr hHandle, int dwMilliseconds);
+		
+        [DllImport("kernel32.dll", SetLastError = true)]
+        static internal extern bool GetOverlappedResult(IntPtr hFile, [In] ref System.Threading.NativeOverlapped lpOverlapped, out uint lpNumberOfBytesTransferred, bool bWait);
 
         [DllImport("kernel32.dll")]
         static internal extern bool WriteFile(IntPtr hFile, byte[] lpBuffer, uint nNumberOfBytesToWrite, out uint lpNumberOfBytesWritten, [In] ref System.Threading.NativeOverlapped lpOverlapped);


### PR DESCRIPTION
This pull request contains fixes for a few issues I saw when testing this library:

1. The WaitForSingleObject appears to be using an incorrect value for INIFINITE timeout.  This causes it to timeout even when ReadReport is called with timeout value of 0.

2. ReadReport return value is not checked before the WaitForSingleObject is called.  If the call succeeds there should no reason to Wait.

3. If the Wait is indeed invoked unless GetOverlappedResult is called the first report received following the wait is lost.

I must say that I only tested this within the context of my own application.  Would appreciate further review and testing.