### PR TITLE
Multitarget to net20, net35, net40 through Theraot.Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _ReSharper.*
 *.suo
 *.log
 .DS_Store
+.vs/

--- a/HidLibrary.nuspec
+++ b/HidLibrary.nuspec
@@ -19,10 +19,10 @@
         <group targetFramework="net20">
           <dependency id="Theraot.Core" version="1.0.3" />
         </group>
-		<group targetFramework="net35">
+        <group targetFramework="net35">
           <dependency id="Theraot.Core" version="1.0.3" />
         </group>
-		<group targetFramework="net40">
+        <group targetFramework="net40">
           <dependency id="Theraot.Core" version="1.0.3" />
         </group>
       </dependencies>

--- a/HidLibrary.nuspec
+++ b/HidLibrary.nuspec
@@ -19,6 +19,12 @@
         <group targetFramework="net20">
           <dependency id="Theraot.Core" version="1.0.3" />
         </group>
+		<group targetFramework="net35">
+          <dependency id="Theraot.Core" version="1.0.3" />
+        </group>
+		<group targetFramework="net40">
+          <dependency id="Theraot.Core" version="1.0.3" />
+        </group>
       </dependencies>
    </metadata>
 </package>

--- a/HidLibrary.nuspec
+++ b/HidLibrary.nuspec
@@ -15,5 +15,10 @@
       <summary>This library enables you to enumerate and communicate with Hid compatible USB devices in .NET.</summary>
       <iconUrl>https://github.com/mikeobrien/HidLibrary/raw/master/misc/logo.png</iconUrl>
       <tags>usb hid</tags>
+      <dependencies>
+        <group targetFramework="net20">
+          <dependency id="Theraot.Core" version="1.0.3" />
+        </group>
+      </dependencies>
    </metadata>
 </package>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ gulp.task('build', ['assemblyInfo'], function() {
     return gulp
         .src('src/*.sln')
         .pipe(msbuild({
-            toolsVersion: 4.0,
+            toolsVersion: 'auto',
             targets: ['Clean', 'Build'],
             errorOnFail: true,
             stdout: true
@@ -43,7 +43,7 @@ gulp.task('test', ['build'], function () {
 
 gulp.task('nuget-package', ['build'], function() {
 
-    gulp.src('src/HidLibrary/bin/Release/HidLibrary.*')
+    gulp.src('src/HidLibrary/bin/Release/**/HidLibrary.*')
         .pipe(gulp.dest('package/lib'));
 
     return Nuget()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "gulp": "^3.8.10",
     "gulp-dotnet-assembly-info": "^0.1.10",
-    "gulp-msbuild": "^0.2.5",
+    "gulp-msbuild": "^0.5.4",
     "gulp-nunit-runner": "^0.4.1",
     "nuget-runner": "^0.1.5",
     "yargs": "^1.3.3"

--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -614,7 +614,12 @@ namespace HidLibrary
                     {
                         var success = NativeMethods.ReadFile(Handle, nonManagedBuffer, (uint)buffer.Length, out bytesRead, ref overlapped);
 
-                        if (!success) {
+                        if (success) 
+                        {
+                            status = HidDeviceData.ReadStatus.Success; // No check here to see if bytesRead > 0 . Perhaps not necessary?
+                        }
+                        else
+                        {
                             var result = NativeMethods.WaitForSingleObject(overlapped.EventHandle, overlapTimeout);
 
                             switch (result) 

--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -150,7 +150,7 @@ namespace HidLibrary
         public async Task<HidDeviceData> ReadAsync(int timeout = 0)
         {
             var readDelegate = new ReadDelegate(Read);
-#if NET20
+#if NET20 || NET35
             return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
 #else
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
@@ -182,7 +182,7 @@ namespace HidLibrary
         public async Task<HidReport> ReadReportAsync(int timeout = 0)
         {
             var readReportDelegate = new ReadReportDelegate(ReadReport);
-#if NET20
+#if NET20 || NET35
             return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
 #else
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);
@@ -365,7 +365,7 @@ namespace HidLibrary
         public async Task<bool> WriteAsync(byte[] data, int timeout = 0)
         {
             var writeDelegate = new WriteDelegate(Write);
-#if NET20
+#if NET20 || NET35
             return await Task<bool>.Factory.StartNew(() => writeDelegate.Invoke(data, timeout));
 #else
             return await Task<bool>.Factory.FromAsync(writeDelegate.BeginInvoke, writeDelegate.EndInvoke, data, timeout, null);
@@ -416,7 +416,7 @@ namespace HidLibrary
         public async Task<bool> WriteReportAsync(HidReport report, int timeout = 0)
         {
             var writeReportDelegate = new WriteReportDelegate(WriteReport);
-#if NET20
+#if NET20 || NET35
             return await Task<bool>.Factory.StartNew(() => writeReportDelegate.Invoke(report, timeout));
 #else
             return await Task<bool>.Factory.FromAsync(writeReportDelegate.BeginInvoke, writeReportDelegate.EndInvoke, report, timeout, null);

--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -150,7 +150,11 @@ namespace HidLibrary
         public async Task<HidDeviceData> ReadAsync(int timeout = 0)
         {
             var readDelegate = new ReadDelegate(Read);
+#if NET20
+            return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
+#else
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
+#endif
         }
 
         public HidReport ReadReport()
@@ -178,7 +182,11 @@ namespace HidLibrary
         public async Task<HidReport> ReadReportAsync(int timeout = 0)
         {
             var readReportDelegate = new ReadReportDelegate(ReadReport);
+#if NET20
+            return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
+#else
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);
+#endif
         }
 
         /// <summary>
@@ -357,7 +365,11 @@ namespace HidLibrary
         public async Task<bool> WriteAsync(byte[] data, int timeout = 0)
         {
             var writeDelegate = new WriteDelegate(Write);
+#if NET20
+            return await Task<bool>.Factory.StartNew(() => writeDelegate.Invoke(data, timeout));
+#else
             return await Task<bool>.Factory.FromAsync(writeDelegate.BeginInvoke, writeDelegate.EndInvoke, data, timeout, null);
+#endif
         }
 
         public bool WriteReport(HidReport report)
@@ -404,7 +416,11 @@ namespace HidLibrary
         public async Task<bool> WriteReportAsync(HidReport report, int timeout = 0)
         {
             var writeReportDelegate = new WriteReportDelegate(WriteReport);
+#if NET20
+            return await Task<bool>.Factory.StartNew(() => writeReportDelegate.Invoke(report, timeout));
+#else
             return await Task<bool>.Factory.FromAsync(writeReportDelegate.BeginInvoke, writeReportDelegate.EndInvoke, report, timeout, null);
+#endif
         }
 
         public HidReport CreateReport()

--- a/src/HidLibrary/HidFastReadDevice.cs
+++ b/src/HidLibrary/HidFastReadDevice.cs
@@ -42,7 +42,7 @@ namespace HidLibrary
         public async Task<HidDeviceData> FastReadAsync(int timeout = 0)
         {
             var readDelegate = new ReadDelegate(FastRead);
-#if NET20
+#if NET20 || NET35
             return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
 #else
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
@@ -74,7 +74,7 @@ namespace HidLibrary
         public async Task<HidReport> FastReadReportAsync(int timeout = 0)
         {
             var readReportDelegate = new ReadReportDelegate(FastReadReport);
-#if NET20
+#if NET20 || NET35
             return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
 #else
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);

--- a/src/HidLibrary/HidFastReadDevice.cs
+++ b/src/HidLibrary/HidFastReadDevice.cs
@@ -42,7 +42,11 @@ namespace HidLibrary
         public async Task<HidDeviceData> FastReadAsync(int timeout = 0)
         {
             var readDelegate = new ReadDelegate(FastRead);
+#if NET20
+            return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
+#else
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
+#endif
         }
 
         public HidReport FastReadReport()
@@ -70,7 +74,11 @@ namespace HidLibrary
         public async Task<HidReport> FastReadReportAsync(int timeout = 0)
         {
             var readReportDelegate = new ReadReportDelegate(FastReadReport);
+#if NET20
+            return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
+#else
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);
+#endif
         }
     }
 }

--- a/src/HidLibrary/HidLibrary.csproj
+++ b/src/HidLibrary/HidLibrary.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,9 +10,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HidLibrary</RootNamespace>
     <AssemblyName>HidLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworks>net20;net45</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -36,31 +37,18 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
+    <PackageReference Include="Theraot.Core" Version="1.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net20' ">
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Extensions.cs" />
-    <Compile Include="HidAsyncState.cs" />
-    <Compile Include="HidDevice.cs" />
-    <Compile Include="HidDeviceAttributes.cs" />
-    <Compile Include="HidDeviceCapabilities.cs" />
-    <Compile Include="HidDeviceData.cs" />
-    <Compile Include="HidDeviceEventMonitor.cs" />
-    <Compile Include="HidFastReadDevice.cs" />
-    <Compile Include="HidFastReadEnumerator.cs" />
-    <Compile Include="IHidEnumerator.cs" />
-    <Compile Include="HidDevices.cs" />
-    <Compile Include="HidReport.cs" />
-    <Compile Include="IHidDevice.cs" />
-    <Compile Include="NativeMethods.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/HidLibrary/HidLibrary.csproj
+++ b/src/HidLibrary/HidLibrary.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HidLibrary</RootNamespace>
     <AssemblyName>HidLibrary</AssemblyName>
-    <TargetFrameworks>net20;net45</TargetFrameworks>
+    <TargetFrameworks>net20;net35;net40;net45</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -40,15 +40,17 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net20' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
     <PackageReference Include="Theraot.Core" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net20' ">
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net20' AND '$(TargetFramework)' != 'net35' ">
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>  
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
I'm not sure what is the final build process.
I updated gulpfile.js to support multitarget frameworks.
Please notice that I have updated msbuild (^0.5.4) with toolsVersion 'auto', but I afraid that is needed 15.0 to build new VS 2017 .xproj