### PR TITLE
Fixed WriteReport stalling problem on Windows 10 .NET4.6.2

### DIFF
--- a/src/HidLibrary/IHidDevice.cs
+++ b/src/HidLibrary/IHidDevice.cs
@@ -29,7 +29,8 @@ namespace HidLibrary
         event InsertedEventHandler Inserted;
         event RemovedEventHandler Removed;
 
-        IntPtr Handle { get; }
+        IntPtr ReadHandle { get; }
+        IntPtr WriteHandle { get; }
         bool IsOpen { get; }
         bool IsConnected { get; }
         string Description { get; }

--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -48,10 +48,10 @@ namespace HidLibrary
         [DllImport("kernel32.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Auto)]
         static internal extern bool CancelSynchronousIo(IntPtr hObject);
 
-	    [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+	    [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
 	    static internal extern IntPtr CreateEvent(ref SECURITY_ATTRIBUTES securityAttributes, int bManualReset, int bInitialState, string lpName);
 
-	    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+	    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
 	    static internal extern IntPtr CreateFile(string lpFileName, uint dwDesiredAccess, int dwShareMode, ref SECURITY_ATTRIBUTES lpSecurityAttributes, int dwCreationDisposition, int dwFlagsAndAttributes, int hTemplateFile);
 
         [DllImport("kernel32.dll", SetLastError = true)]
@@ -209,7 +209,7 @@ namespace HidLibrary
 	    [DllImport("setupapi.dll")]
         static internal extern bool SetupDiEnumDeviceInterfaces(IntPtr deviceInfoSet, ref SP_DEVINFO_DATA deviceInfoData, ref Guid interfaceClassGuid, int memberIndex, ref SP_DEVICE_INTERFACE_DATA deviceInterfaceData);
 
-	    [DllImport("setupapi.dll", CharSet = CharSet.Auto)]
+	    [DllImport("setupapi.dll", CharSet = CharSet.Unicode)]
         static internal extern IntPtr SetupDiGetClassDevs(ref System.Guid classGuid, string enumerator, int hwndParent, int flags);
 
         [DllImport("setupapi.dll", CharSet = CharSet.Auto, EntryPoint = "SetupDiGetDeviceInterfaceDetail")]


### PR DESCRIPTION
Creating separate File Handles for Read and Write operations solved problem of stalling WriteReport operation. Looks like there was a problem with using device file with both read and write permissions at the same time