### PR TITLE
Add netstandard2 target to nuspec file.

### DIFF
--- a/HidLibrary.nuspec
+++ b/HidLibrary.nuspec
@@ -25,6 +25,10 @@
         <group targetFramework="net40">
           <dependency id="Theraot.Core" version="1.0.3" />
         </group>
+        <group targetFramework="net45">
+        </group>
+        <group targetFramework="netstandard2">
+        </group>
       </dependencies>
     </metadata>
     <files>
@@ -32,5 +36,6 @@
       <file src="net35\HidLibrary.*" target="lib\net35" exclude="*.xml" />
       <file src="net40\HidLibrary.*" target="lib\net40" exclude="*.xml" />
       <file src="net45\HidLibrary.*" target="lib\net45" exclude="*.xml" />
+      <file src="netstandard2\HidLibrary.*" target="lib\netstandard2" exclude="*.xml" />
     </files>
 </package>


### PR DESCRIPTION
netstandard2 build is already done by src\HidLibrary\HidLibrary.csproj, but output was missing in the nuget package.