### PR TITLE
Add Override to Enumerate by UsagePage

### DIFF
--- a/src/HidLibrary/HidDevices.cs
+++ b/src/HidLibrary/HidDevices.cs
@@ -41,9 +41,15 @@ namespace HidLibrary
             return EnumerateDevices().Select(x => new HidDevice(x.Path, x.Description)).Where(x => x.Attributes.VendorId == vendorId &&
                                                                                   productId == (ushort)x.Attributes.ProductId && (ushort)x.Capabilities.UsagePage == UsagePage);
         }
+        
         public static IEnumerable<HidDevice> Enumerate(int vendorId)
         {
             return EnumerateDevices().Select(x => new HidDevice(x.Path, x.Description)).Where(x => x.Attributes.VendorId == vendorId);
+        }
+
+        public static IEnumerable<HidDevice> Enumerate(ushort UsagePage)
+        {
+            return EnumerateDevices().Select(x => new HidDevice(x.Path, x.Description)).Where(x => (ushort)x.Capabilities.UsagePage == UsagePage);
         }
 
         internal class DeviceInfo { public string Path { get; set; } public string Description { get; set; } }


### PR DESCRIPTION
Simple override to select all devices that match the usage page. This is useful if the machine may have multiple hid devices in the same class, or if trying to find a specific type of device without knowing the specifics of vendor or product id.