### PR TITLE
Add Native Methods to Retrieve Prod/Manu String

### DIFF
--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -211,8 +211,14 @@ namespace HidLibrary
         [DllImport("hid.dll")]
         internal static extern bool HidD_GetProductString(IntPtr hidDeviceObject, ref byte lpReportBuffer, int ReportBufferLength);
 
+        [DllImport("hid.dll"]
+        internal static extern bool HidD_GetProductString(IntPtr hidDeviceObject, ref byte[] lpReportBuffer, int ReportBufferLength);
+
         [DllImport("hid.dll")]
         internal static extern bool HidD_GetManufacturerString(IntPtr hidDeviceObject, ref byte lpReportBuffer, int ReportBufferLength);
+
+        [DllImport("hid.dll")]
+        internal static extern bool HidD_GetManufacturerString(IntPtr hidDeviceObject, ref byte[] lpReportBuffer, int ReportBufferLength);
 
         [DllImport("hid.dll")]
         internal static extern bool HidD_GetSerialNumberString(IntPtr hidDeviceObject, ref byte lpReportBuffer, int reportBufferLength);


### PR DESCRIPTION
The current native methods only retrieve the first byte. These overrides are able to retrieve the entire buffer.