### PR TITLE
Remove Single Byte Limitation from Read Prod/Manu

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -263,7 +263,7 @@ namespace HidLibrary
                 else
                     hidHandle = OpenDeviceIO(_devicePath, NativeMethods.ACCESS_NONE);
 
-                success = NativeMethods.HidD_GetProductString(hidHandle, ref data[0], data.Length);
+                success = NativeMethods.HidD_GetProductString(hidHandle, ref data, data.Length);
             }
             catch (Exception exception)
             {
@@ -290,7 +290,7 @@ namespace HidLibrary
                 else
                     hidHandle = OpenDeviceIO(_devicePath, NativeMethods.ACCESS_NONE);
 
-                success = NativeMethods.HidD_GetManufacturerString(hidHandle, ref data[0], data.Length);
+                success = NativeMethods.HidD_GetManufacturerString(hidHandle, ref data, data.Length);
             }
             catch (Exception exception)
             {


### PR DESCRIPTION
Works in conjunction with PR#125.

Remove the reference to a single byte and instead passes the byte array. The native method will then fill the array up to the limit.