### PR TITLE
Fix Native Methods

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -263,7 +263,7 @@ namespace HidLibrary
                 else
                     hidHandle = OpenDeviceIO(_devicePath, NativeMethods.ACCESS_NONE);
 
-                success = NativeMethods.HidD_GetProductString(hidHandle, ref data[0], data.Length);
+                success = NativeMethods.HidD_GetProductString(hidHandle, data, data.Length);
             }
             catch (Exception exception)
             {
@@ -290,7 +290,7 @@ namespace HidLibrary
                 else
                     hidHandle = OpenDeviceIO(_devicePath, NativeMethods.ACCESS_NONE);
 
-                success = NativeMethods.HidD_GetManufacturerString(hidHandle, ref data[0], data.Length);
+                success = NativeMethods.HidD_GetManufacturerString(hidHandle, data, data.Length);
             }
             catch (Exception exception)
             {
@@ -317,7 +317,7 @@ namespace HidLibrary
                 else
                     hidHandle = OpenDeviceIO(_devicePath, NativeMethods.ACCESS_NONE);
 
-                success = NativeMethods.HidD_GetSerialNumberString(hidHandle, ref data[0], data.Length);
+                success = NativeMethods.HidD_GetSerialNumberString(hidHandle, data, data.Length);
             }
             catch (Exception exception)
             {

--- a/src/HidLibrary/NativeMethods.cs
+++ b/src/HidLibrary/NativeMethods.cs
@@ -209,12 +209,12 @@ namespace HidLibrary
         static internal extern int HidP_GetCaps(IntPtr preparsedData, ref HIDP_CAPS capabilities);
 
         [DllImport("hid.dll")]
-        internal static extern bool HidD_GetProductString(IntPtr hidDeviceObject, ref byte lpReportBuffer, int ReportBufferLength);
+        internal static extern bool HidD_GetProductString(IntPtr hidDeviceObject, byte[] lpReportBuffer, int ReportBufferLength);
 
         [DllImport("hid.dll")]
-        internal static extern bool HidD_GetManufacturerString(IntPtr hidDeviceObject, ref byte lpReportBuffer, int ReportBufferLength);
+        internal static extern bool HidD_GetManufacturerString(IntPtr hidDeviceObject, byte[] lpReportBuffer, int ReportBufferLength);
 
         [DllImport("hid.dll")]
-        internal static extern bool HidD_GetSerialNumberString(IntPtr hidDeviceObject, ref byte lpReportBuffer, int reportBufferLength);
+        internal static extern bool HidD_GetSerialNumberString(IntPtr hidDeviceObject, byte[] lpReportBuffer, int reportBufferLength);
     }
 }


### PR DESCRIPTION
Current methods do not fill the array correctly, only the first byte. This fills the byte array correctly, meaning a simple byte array to string conversion can be applied.

All the method headers use a void pointer, so we can safely pass the byte array and rely on the lib to fill it correctly.
https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/hidsdi/