### PR TITLE
[.NET 5 & 6] Add NET5_0 or greater compatibility

### DIFF
--- a/src/HidLibrary/HidDevice.cs
+++ b/src/HidLibrary/HidDevice.cs
@@ -154,7 +154,7 @@ namespace HidLibrary
         public async Task<HidDeviceData> ReadAsync(int timeout = 0)
         {
             var readDelegate = new ReadDelegate(Read);
-#if NET20 || NET35
+#if NET20 || NET35 || NET5_0_OR_GREATER
             return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
 #else
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
@@ -186,7 +186,7 @@ namespace HidLibrary
         public async Task<HidReport> ReadReportAsync(int timeout = 0)
         {
             var readReportDelegate = new ReadReportDelegate(ReadReport);
-#if NET20 || NET35
+#if NET20 || NET35 || NET5_0_OR_GREATER
             return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
 #else
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);
@@ -369,7 +369,7 @@ namespace HidLibrary
         public async Task<bool> WriteAsync(byte[] data, int timeout = 0)
         {
             var writeDelegate = new WriteDelegate(Write);
-#if NET20 || NET35
+#if NET20 || NET35 || NET5_0_OR_GREATER
             return await Task<bool>.Factory.StartNew(() => writeDelegate.Invoke(data, timeout));
 #else
             return await Task<bool>.Factory.FromAsync(writeDelegate.BeginInvoke, writeDelegate.EndInvoke, data, timeout, null);
@@ -420,7 +420,7 @@ namespace HidLibrary
         public async Task<bool> WriteReportAsync(HidReport report, int timeout = 0)
         {
             var writeReportDelegate = new WriteReportDelegate(WriteReport);
-#if NET20 || NET35
+#if NET20 || NET35 || NET5_0_OR_GREATER
             return await Task<bool>.Factory.StartNew(() => writeReportDelegate.Invoke(report, timeout));
 #else
             return await Task<bool>.Factory.FromAsync(writeReportDelegate.BeginInvoke, writeReportDelegate.EndInvoke, report, timeout, null);

--- a/src/HidLibrary/HidDeviceEventMonitor.cs
+++ b/src/HidLibrary/HidDeviceEventMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace HidLibrary
 {
@@ -21,8 +22,12 @@ namespace HidLibrary
 
         public void Init()
         {
-            var eventMonitor = new Action(DeviceEventMonitor);
-            eventMonitor.BeginInvoke(DisposeDeviceEventMonitor, eventMonitor);
+#if NET20 || NET35 || NET5_0_OR_GREATER
+            Task task = Task.Factory.StartNew(() => DeviceEventMonitor());
+#else
+             var eventMonitor = new Action(DeviceEventMonitor);
+             eventMonitor.BeginInvoke(DisposeDeviceEventMonitor, eventMonitor);
+#endif
         }
 
         private void DeviceEventMonitor()

--- a/src/HidLibrary/HidFastReadDevice.cs
+++ b/src/HidLibrary/HidFastReadDevice.cs
@@ -42,7 +42,7 @@ namespace HidLibrary
         public async Task<HidDeviceData> FastReadAsync(int timeout = 0)
         {
             var readDelegate = new ReadDelegate(FastRead);
-#if NET20 || NET35
+#if NET20 || NET35 || NET5_0_OR_GREATER
             return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
 #else
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
@@ -74,7 +74,7 @@ namespace HidLibrary
         public async Task<HidReport> FastReadReportAsync(int timeout = 0)
         {
             var readReportDelegate = new ReadReportDelegate(FastReadReport);
-#if NET20 || NET35
+#if NET20 || NET35 || NET5_0_OR_GREATER
             return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
 #else
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);


### PR DESCRIPTION
Add NET5_0 or greater compatibility.

We had to make those changes to include HIdLibrary in our .NET6 solution.