### PR TITLE
Improve compatibility with .NET Core and later (including .NET 5 and above)

### DIFF
--- a/src/HidLibrary/HidAsyncState.cs
+++ b/src/HidLibrary/HidAsyncState.cs
@@ -1,5 +1,10 @@
 ﻿namespace HidLibrary
 {
+#if !NETCOREAPP1_0_OR_GREATER
+    // data provided to delegate BeginInvoke callbacks
+    // no longer needed for .NET Core and later (includes .NET 5 and above) since BeginInvoke and EndInvoke delegate
+    // calls are not supported, and Task<> is used instead
+
     public class HidAsyncState
     {
         private readonly object _callerDelegate;
@@ -14,4 +19,5 @@
         public object CallerDelegate { get { return _callerDelegate; } }
         public object CallbackDelegate { get { return _callbackDelegate; } }
     }
+#endif
 }

--- a/src/HidLibrary/HidDeviceEventMonitor.cs
+++ b/src/HidLibrary/HidDeviceEventMonitor.cs
@@ -22,7 +22,7 @@ namespace HidLibrary
 
         public void Init()
         {
-#if NET20 || NET35 || NET5_0_OR_GREATER
+#if NET20 || NET35 || NETCOREAPP1_0_OR_GREATER
             Task task = Task.Factory.StartNew(() => DeviceEventMonitor());
 #else
              var eventMonitor = new Action(DeviceEventMonitor);

--- a/src/HidLibrary/HidFastReadDevice.cs
+++ b/src/HidLibrary/HidFastReadDevice.cs
@@ -34,17 +34,23 @@ namespace HidLibrary
 
         public void FastRead(ReadCallback callback, int timeout)
         {
+#if NETCOREAPP1_0_OR_GREATER
+            // start new task with FastRead() and call callback afterwards
+            Task<HidDeviceData> readTask = Task.Run(() => FastRead(timeout));
+            readTask.ContinueWith(task => callback.Invoke(task.Result));
+#else
             var readDelegate = new ReadDelegate(FastRead);
             var asyncState = new HidAsyncState(readDelegate, callback);
             readDelegate.BeginInvoke(timeout, EndRead, asyncState);
+#endif
         }
 
         public async Task<HidDeviceData> FastReadAsync(int timeout = 0)
         {
-            var readDelegate = new ReadDelegate(FastRead);
-#if NET20 || NET35 || NET5_0_OR_GREATER
-            return await Task<HidDeviceData>.Factory.StartNew(() => readDelegate.Invoke(timeout));
+#if NET20 || NET35 || NETCOREAPP1_0_OR_GREATER
+            return await Task<HidDeviceData>.Factory.StartNew(() => FastRead(timeout));
 #else
+            var readDelegate = new ReadDelegate(FastRead);
             return await Task<HidDeviceData>.Factory.FromAsync(readDelegate.BeginInvoke, readDelegate.EndInvoke, timeout, null);
 #endif
         }
@@ -66,17 +72,23 @@ namespace HidLibrary
 
         public void FastReadReport(ReadReportCallback callback, int timeout)
         {
+#if NETCOREAPP1_0_OR_GREATER
+            // start new task with FastReadReport() and call callback afterwards
+            Task<HidReport> readReportTask = Task.Run(() => FastReadReport(timeout));
+            readReportTask.ContinueWith(task => callback.Invoke(task.Result));
+#else
             var readReportDelegate = new ReadReportDelegate(FastReadReport);
             var asyncState = new HidAsyncState(readReportDelegate, callback);
             readReportDelegate.BeginInvoke(timeout, EndReadReport, asyncState);
+#endif
         }
 
         public async Task<HidReport> FastReadReportAsync(int timeout = 0)
         {
-            var readReportDelegate = new ReadReportDelegate(FastReadReport);
-#if NET20 || NET35 || NET5_0_OR_GREATER
-            return await Task<HidReport>.Factory.StartNew(() => readReportDelegate.Invoke(timeout));
+#if NET20 || NET35 || NETCOREAPP1_0_OR_GREATER
+            return await Task<HidReport>.Factory.StartNew(() => FastReadReport(timeout));
 #else
+            var readReportDelegate = new ReadReportDelegate(FastReadReport);
             return await Task<HidReport>.Factory.FromAsync(readReportDelegate.BeginInvoke, readReportDelegate.EndInvoke, timeout, null);
 #endif
         }


### PR DESCRIPTION
.NET Core and later (includes .NET Platform 5 and above) no longer supports delegate `BeginInvoke` and `EndInvoke`. See e.g. [this blog post from Mike Rousos](https://devblogs.microsoft.com/dotnet/migrating-delegate-begininvoke-calls-for-net-core/) for details. I changed the corresponding code in `HidDevice.cs` and `HidFastReadDevice.cs` to use [`Task`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task?view=net-8.0) instead.

Note I only tested this with .NET 6.0.

The changes should work on .NET Core and .NET Platform 5 and above. They should also work on .NET framework 4.5 and above, since the corresponding features ([`Task.Run()`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.run), [`Task.ContinueWith()`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.continuewith), [`Task.Factory`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.factory) and [`TaskFactory.StartNew()`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskfactory.startnew)) are available there also according to the docs.

I also modified some code provided earlier in two regards:
1. call corresponding functions directly in the lambda expression supplied to `TaskFactory.StartNew()` instead of using `delegate.Invoke()` (needs less code and is easier to read),
2. changed the preprocessor symbols used in the `#if` switches from `NET5_0_OR_GREATER` to `NETCOREAPP1_0_OR_GREATER`, since that should be the appropriate symbol according to [the docs](https://learn.microsoft.com/en-us/dotnet/standard/frameworks).

Note: On .NET Platform 6 at least, the dependency on the `Theraot.Core` nuget can be removed, because the corresponding backport is no longer needed there.

Any review is appreciated. Hope this helps others using this library.